### PR TITLE
Fix species id datasource issue

### DIFF
--- a/app/api/api_v1/endpoints/data_sources.py
+++ b/app/api/api_v1/endpoints/data_sources.py
@@ -9,7 +9,7 @@ from app.api import deps
 router = APIRouter()
 
 
-@router.get("/", response_model=List[schemas.DataSource])
+@router.get("/", response_model=List[schemas.DataSourceIDOnly])
 def read_data_source(
     db: Session = Depends(deps.get_db),
     skip: int = 0,

--- a/app/api/api_v1/endpoints/data_sources.py
+++ b/app/api/api_v1/endpoints/data_sources.py
@@ -20,7 +20,7 @@ def read_data_source(
     return data_sources
 
 
-@router.get("/{data_source_id}", response_model=schemas.DataSource)
+@router.get("/{data_source_id}", response_model=schemas.DataSourceIDOnly)
 def read_data_source_by_id(
     data_source_id: int,
     db: Session = Depends(deps.get_db),

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -3,6 +3,7 @@ from .data_source import (
     DataSourceCreate,
     DataSourceInDB,
     DataSourceUpdate,
+    DataSourceIDOnly,
 )
 from .geojson import Point
 from .msg import Msg

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,13 +1,11 @@
 from .data_source import (
-    DataSource,
     DataSourceCreate,
-    DataSourceInDB,
     DataSourceUpdate,
     DataSourceIDOnly,
 )
 from .geojson import Point
 from .msg import Msg
-from .species import Species, SpeciesCreate, SpeciesInDB, SpeciesUpdate
+from .species import Species, SpeciesCreate, SpeciesInDB, SpeciesUpdate, SpeciesID
 from .station import Station, StationCreate, StationInDB, StationUpdate
 from .token import Token, TokenPayload
 from .user import User, UserCreate, UserInDB, UserUpdate

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,4 +1,9 @@
-from .data_source import DataSource, DataSourceCreate, DataSourceInDB, DataSourceUpdate
+from .data_source import (
+    DataSource,
+    DataSourceCreate,
+    DataSourceInDB,
+    DataSourceUpdate,
+)
 from .geojson import Point
 from .msg import Msg
 from .species import Species, SpeciesCreate, SpeciesInDB, SpeciesUpdate

--- a/app/schemas/data_source.py
+++ b/app/schemas/data_source.py
@@ -5,7 +5,7 @@ from typing import List
 
 from pydantic import BaseModel
 
-from app.schemas.species import Species
+from app.schemas.species import Species, SpeciesID
 
 
 class DataSourceBase(BaseModel):
@@ -26,6 +26,17 @@ class DataSourceInDB(DataSourceBase):
 
     class Config:
         orm_mode = True
+
+
+class DataSourceInDBIDOnly(DataSourceBase):
+    species: List[SpeciesID]
+
+    class Config:
+        orm_mode = True
+
+
+class DataSourceIDOnly(DataSourceInDBIDOnly):
+    pass
 
 
 class DataSource(DataSourceInDB):

--- a/app/schemas/data_source.py
+++ b/app/schemas/data_source.py
@@ -21,13 +21,6 @@ class DataSourceUpdate(DataSourceBase):
     pass
 
 
-class DataSourceInDB(DataSourceBase):
-    species: List[Species]
-
-    class Config:
-        orm_mode = True
-
-
 class DataSourceInDBIDOnly(DataSourceBase):
     species: List[SpeciesID]
 
@@ -36,8 +29,4 @@ class DataSourceInDBIDOnly(DataSourceBase):
 
 
 class DataSourceIDOnly(DataSourceInDBIDOnly):
-    pass
-
-
-class DataSource(DataSourceInDB):
     pass

--- a/app/schemas/species.py
+++ b/app/schemas/species.py
@@ -17,6 +17,11 @@ class SpeciesBase(BaseModel):
     data_source_id: int
 
 
+class SpeciesBaseIDOnly(BaseModel):
+    id: str
+    data_source_id: int
+
+
 class SpeciesCreate(SpeciesBase):
     pass
 

--- a/app/schemas/species.py
+++ b/app/schemas/species.py
@@ -1,6 +1,6 @@
 """Pydantic models for representing species extracted by `challenger-workflows`.
 """
-from typing import Optional
+from typing import List, Optional
 
 from pydantic import BaseModel
 
@@ -19,7 +19,6 @@ class SpeciesBase(BaseModel):
 
 class SpeciesBaseIDOnly(BaseModel):
     id: str
-    data_source_id: int
 
 
 class SpeciesCreate(SpeciesBase):

--- a/app/schemas/species.py
+++ b/app/schemas/species.py
@@ -37,3 +37,12 @@ class SpeciesInDB(SpeciesBase):
 
 class Species(SpeciesInDB):
     pass
+
+
+class SpeciesIDOnlyInDB(SpeciesBaseIDOnly):
+    class Config:
+        orm_mode = True
+
+
+class SpeciesID(SpeciesIDOnlyInDB):
+    pass

--- a/app/schemas/station.py
+++ b/app/schemas/station.py
@@ -8,7 +8,7 @@ from geoalchemy2 import WKBElement
 from pydantic import BaseModel, validator
 
 from app.schemas.geojson import Point
-from app.schemas.species import Species
+from app.schemas.species import SpeciesID
 
 
 class StationBase(BaseModel):
@@ -47,7 +47,8 @@ class StationUpdate(StationBase):
 
 
 class StationInDB(StationBase):
-    species: List[Species]
+    species: List[SpeciesID]
+    # species: SpeciesID
 
     class Config:
         orm_mode = True


### PR DESCRIPTION
This pull request adds 2 new classes to the `data_source.py` and `species.py` schemas namely `DataSourceInDBIDOnly`, `DataSourceIDOnly` and `SpeciesIDOnlyInDB`, `SpeciesID` respectively. Now the API endpoint `/api/v1/data_source/` will serve data in the format as specified below.

`[
  {
    "id": 0,
    "title": "string",
    "species": [
      {
        "id": "string",
        "data_source_id": 0
      }
    ]
  }
]`