### PR TITLE
Add support for multi-column search

### DIFF
--- a/app/api/api_v1/endpoints/species.py
+++ b/app/api/api_v1/endpoints/species.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Union
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
@@ -30,21 +30,17 @@ def read_all_species(
     return species
 
 
-@router.get("/search/", response_model=List[schemas.SpeciesSummary])
+@router.post("/search/", response_model=List[schemas.SpeciesSummary])
 def read_species_by_search(
-    search_term: str,
-    search_column: str,
+    expressions: Union[schemas.Expression, schemas.ExpressionGroup],
     db: Session = Depends(deps.get_db),
     limit: int = 0,
     order_by: Optional[List[str]] = Query(None),
 ) -> Any:
-    """Retrieves the species based on the
-    requested search params.
-    """
+    """Retrieves the species based on the given search expressions."""
     species = crud.species.search(
         db,
-        search_column=search_column,
-        search_term=search_term,
+        expressions=expressions,
         order_by=order_by,
         limit=limit,
     )

--- a/app/api/api_v1/endpoints/stations.py
+++ b/app/api/api_v1/endpoints/stations.py
@@ -1,10 +1,11 @@
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Union
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
 from app import crud, schemas
 from app.api import deps
+from app.models import stations_species_table
 
 router = APIRouter()
 
@@ -31,18 +32,18 @@ def read_all_stations(
     return stations
 
 
-@router.get("/search/", response_model=List[schemas.StationSummary])
+@router.post("/search/", response_model=List[schemas.StationSummary])
 def read_stations_by_search(
-    search_term: str,
-    search_column: str,
+    expressions: Union[schemas.Expression, schemas.ExpressionGroup],
     db: Session = Depends(deps.get_db),
     limit: int = 0,
     order_by: Optional[List[str]] = Query(None),
 ) -> Any:
+    """Retrieves the stations based on the given search expressions."""
     stations = crud.station.search(
         db,
-        search_column=search_column,
-        search_term=search_term,
+        expressions=expressions,
+        relations=[stations_species_table],
         order_by=order_by,
         limit=limit,
     )

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -5,6 +5,7 @@ from .data_source import (
     DataSourceUpdate,
 )
 from .msg import Msg
+from .search import Expression, ExpressionGroup, Join, Operator
 from .species import (
     SpeciesCreate,
     SpeciesDetails,

--- a/app/schemas/search.py
+++ b/app/schemas/search.py
@@ -1,0 +1,50 @@
+from enum import Enum
+from typing import Any, Dict, List, Optional, Union
+
+from pydantic import BaseModel, Field, validator
+
+
+class Operator(str, Enum):
+    eq = "eq"  # ==
+    ne = "ne"  # !=
+    gt = "gt"  # >
+    gte = "ge"  # >=
+    lt = "lt"  # <
+    lte = "le"  # <=
+    contains = "contains"  # if iterable contains the given value (not tested)
+    # TODO add more operators
+
+
+class Join(str, Enum):
+    AND = "AND"
+    OR = "OR"
+
+
+class Expression(BaseModel):
+    column_name: str
+    search_term: str
+    operator: Operator
+    fuzzy: bool = False
+    min_string_similarity: Optional[float] = Field(default=0.1)
+
+
+class ExpressionGroup(BaseModel):
+    join: Optional[Join]
+    expressions: List[Union[Expression, "ExpressionGroup"]] = Field(min_items=1)
+
+    @validator("expressions")
+    def expressions_validator(
+        cls,
+        v: List[Union[Expression, "ExpressionGroup"]],
+        values: Dict[str, Any],
+    ) -> List[Union[Expression, "ExpressionGroup"]]:
+        join = values.get("join")
+        expressions_length = len(v)
+        if not join and expressions_length > 1:
+            raise ValueError("a join operator is needed for multiple expression")
+        if join and expressions_length == 1:
+            raise ValueError("a join operator is not needed for one expression")
+        return v
+
+
+ExpressionGroup.update_forward_refs()


### PR DESCRIPTION
You can now pass a group of expressions to the search endpoint to filter the records using multiple columns joined together by `AND` and `OR`.

Note that `/search` now accepts `post` requests. Here's an example of a search expression group:
```{json}
        {
          "join": "AND",
          "expressions": [
            {
              "column_name": "fao_area",
              "search_term": "27",
              "operator": "eq"
            },
            {
              "join": "OR",
              "expressions": [
                {
                  "column_name": "species_id",
                  "search_term": "b92a3b6f-8816-5c29-ba10-83bc78eab8ae",
                  "operator": "eq"
                },
                {
                  "column_name": "species_id",
                  "search_term": "a57a7c8b-1b3b-57f9-8101-f456834d18ea",
                  "operator": "eq"
                }
              ]
            }
          ]
        }
```

This example searches for all stations that are in the FAO area 27 and have at least one of the species given by their IDs.
See the docstring for the new methods on `CRUDBase` for more details.

Resolves #45 