### PR TITLE
Add outer join support for station species

### DIFF
--- a/app/api/api_v1/endpoints/data_sources.py
+++ b/app/api/api_v1/endpoints/data_sources.py
@@ -3,7 +3,7 @@ from typing import Any, List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from app import crud, models, schemas
+from app import crud, schemas
 from app.api import deps
 
 router = APIRouter()

--- a/app/api/api_v1/endpoints/data_sources.py
+++ b/app/api/api_v1/endpoints/data_sources.py
@@ -33,11 +33,14 @@ def read_all_data_sources(
     return data_sources
 
 
-@router.get("/{data_source_id}", response_model=schemas.DataSourceDetails)
+@router.get(
+    "/{data_source_id}",
+    response_model=schemas.DataSourceDetails,
+)
 def read_data_source_by_id(
     data_source_id: int,
     db: Session = Depends(deps.get_db),
-    current_user: models.User = Depends(deps.get_current_user),
+    # current_user: Optional[models.User] = Depends(deps.get_current_user),
 ) -> Any:
     """Get a data source by id."""
     data_source = crud.data_source.get(db, id=data_source_id)

--- a/app/api/api_v1/endpoints/species.py
+++ b/app/api/api_v1/endpoints/species.py
@@ -47,7 +47,10 @@ def read_species_by_search(
     return species
 
 
-@router.get("/{species_id}", response_model=schemas.SpeciesDetails)
+@router.get(
+    "/{species_id}",
+    response_model=schemas.SpeciesDetails,
+)
 def read_species_by_id(
     species_id: str,
     db: Session = Depends(deps.get_db),

--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -1,4 +1,4 @@
-from typing import Generator, Optional
+from typing import Generator
 
 from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer

--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -1,6 +1,6 @@
-from typing import Generator
+from typing import Generator, Optional
 
-from fastapi import Security, Depends, HTTPException, status
+from fastapi import Security, Depends, HTTPException, status, Header
 from fastapi.security import OAuth2PasswordBearer
 from fastapi.security.api_key import APIKeyQuery, APIKeyCookie, APIKeyHeader, APIKey
 from jose import jwt

--- a/app/crud/base.py
+++ b/app/crud/base.py
@@ -263,11 +263,12 @@ class CRUDBase(
 
         if relations:
             for relation in relations:
-                query = query.join(relation)
+                query = query.join(relation, isouter=True)
 
         query = query.filter(*search_expressions["clauses"]).order_by(
             *map(lambda f: f.desc(), search_expressions["fuzzy_funcs"])
         )
+
         ordered_query = self.order_by(query, order_by=order_by)
 
         if limit > 0:

--- a/app/main.py
+++ b/app/main.py
@@ -33,11 +33,4 @@ if settings.BACKEND_CORS_ORIGINS:
         allow_headers=["*"],
     )
 
-
-@app.middleware("http")
-def test(request: Request, call_next):
-    print(request.client)
-    return call_next(request)
-
-
 app.include_router(api_router, prefix=settings.API_V1_STR)

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, Request
+from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 


### PR DESCRIPTION
Added `outerjoin=True` which now enables all the stations to be allowed in the resulting query after adding all the species to their respective stations.